### PR TITLE
fix white/red sauces behavior

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -84,9 +84,9 @@ function renderWhiteSauce() {
   // Iteration 2: add/remove the class "sauce-white" of `<section class="sauce">`
   document.querySelectorAll( '.sauce' ).forEach( item => {
     if ( state.sauce ) {
-      item.style.visibility = 'visible';
+      item.classList.remove("sauce-white");
     } else {
-      item.style.visibility = 'hidden';
+      item.classList.add("sauce-white");
     }
   } );
 }


### PR DESCRIPTION
Instead of showing/hiding the sauce element, this commit removes/adds the class ".white-sauce" to the elements with the class ".sauce".

Now we can see both the red or the white sauces depending on the whiteSauce state.